### PR TITLE
Migrate from `failure` to `anyhow`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-failure = "0.1.2"
+anyhow = "1.0.0"
 log = "0.4.1"
 
 [dev-dependencies]

--- a/examples/fix-json.rs
+++ b/examples/fix-json.rs
@@ -1,6 +1,4 @@
-use rustfix;
-
-use failure::Error;
+use anyhow::Error;
 use std::io::{stdin, BufReader, Read};
 use std::{collections::HashMap, collections::HashSet, env, fs};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@
 
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate failure;
 #[cfg(test)]
 #[macro_use]
 extern crate proptest;
@@ -12,7 +10,7 @@ use serde_json;
 use std::collections::HashSet;
 use std::ops::Range;
 
-use failure::Error;
+use anyhow::Error;
 
 pub mod diagnostics;
 use crate::diagnostics::{Diagnostic, DiagnosticSpan};

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -2,7 +2,7 @@
 //! replacement of parts of its content, with the ability to prevent changing
 //! the same parts multiple times.
 
-use anyhow::{Error, ensure, anyhow};
+use anyhow::{anyhow, ensure, Error};
 use std::rc::Rc;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -2,7 +2,7 @@
 //! replacement of parts of its content, with the ability to prevent changing
 //! the same parts multiple times.
 
-use failure::Error;
+use anyhow::{Error, ensure, anyhow};
 use std::rc::Rc;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -133,7 +133,7 @@ impl Data {
                         );
                     }
 
-                    format_err!(
+                    anyhow!(
                         "Could not replace range {}...{} in file \
                          -- maybe parts of it were already replaced?",
                         from,

--- a/tests/parse_and_replace.rs
+++ b/tests/parse_and_replace.rs
@@ -1,15 +1,15 @@
 #![cfg(not(windows))] // TODO: should fix these tests on Windows
 
+use anyhow::{anyhow, ensure, Context, Error};
+use log::{debug, info, warn};
+use rustfix::apply_suggestions;
 use std::collections::HashSet;
 use std::env;
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Output;
-use anyhow::{Error, Context, ensure, anyhow};
 use tempdir::TempDir;
-use rustfix::apply_suggestions;
-use log::{info, warn, debug};
 
 mod fixmode {
     pub const EVERYTHING: &str = "yolo";

--- a/tests/parse_and_replace.rs
+++ b/tests/parse_and_replace.rs
@@ -1,25 +1,15 @@
 #![cfg(not(windows))] // TODO: should fix these tests on Windows
 
-use duct;
-use env_logger;
-#[macro_use]
-extern crate log;
-use rustfix;
-
-#[macro_use]
-extern crate failure;
-
 use std::collections::HashSet;
 use std::env;
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Output;
-
-use failure::{Error, ResultExt};
+use anyhow::{Error, Context, ensure, anyhow};
 use tempdir::TempDir;
-
 use rustfix::apply_suggestions;
+use log::{info, warn, debug};
 
 mod fixmode {
     pub const EVERYTHING: &str = "yolo";
@@ -67,7 +57,7 @@ fn compile_and_get_json_errors(file: &Path, mode: &str) -> Result<String, Error>
 
     match res.status.code() {
         Some(0) | Some(1) | Some(101) => Ok(stderr),
-        _ => Err(format_err!(
+        _ => Err(anyhow!(
             "failed with status {:?}: {}",
             res.status.code(),
             stderr
@@ -86,7 +76,7 @@ fn compiles_without_errors(file: &Path, mode: &str) -> Result<(), Error> {
                 file,
                 String::from_utf8(res.stderr)?
             );
-            Err(format_err!(
+            Err(anyhow!(
                 "failed with status {:?} (`env RUST_LOG=parse_and_replace=info` for more info)",
                 res.status.code(),
             ))
@@ -226,10 +216,7 @@ fn assert_fixtures(dir: &str, mode: &str) {
     for file in &files {
         if let Err(err) = test_rustfix_with_file(file, mode) {
             println!("failed: {}", file.display());
-            warn!("{}", err);
-            for cause in err.iter_chain().skip(1) {
-                info!("\tcaused by: {}", cause);
-            }
+            warn!("{:?}", err);
             failures += 1;
         }
         info!("passed: {:?}", file);


### PR DESCRIPTION
This moves from a custom error trait to the standard `Error` trait,
improving ecosystem interoperability.