### PR TITLE
Switch to similar from difference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,6 @@ env_logger = "0.5.0-rc.1"
 log = "0.4.1"
 tempdir = "0.3.5"
 proptest = "0.7.0"
-difference = "2.0.0"
+similar = "0.4.0"
 
 [workspace]


### PR DESCRIPTION
Since difference.rs is unmaintained I made the liberty of creating a pull request replacing it with my similar crate.

For more information see https://rustsec.org/advisories/RUSTSEC-2020-0095.html