### PR TITLE
Fix panic computing indentation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ fn parse_snippet(span: &DiagnosticSpan) -> Option<Snippet> {
                 .chars()
                 .take_while(|&c| char::is_whitespace(c))
                 .count();
-            std::cmp::min(indent, line.highlight_start)
+            std::cmp::min(indent, line.highlight_start - 1)
         })
         .min()?;
 

--- a/tests/edge-cases/indented_whitespace.json
+++ b/tests/edge-cases/indented_whitespace.json
@@ -1,0 +1,60 @@
+{
+    "message": "non-ASCII whitespace symbol '\\u{a0}' is not skipped",
+    "code": null,
+    "level": "warning",
+    "spans":
+    [
+        {
+            "file_name": "lib.rs",
+            "byte_start": 26,
+            "byte_end": 28,
+            "line_start": 2,
+            "line_end": 2,
+            "column_start": 1,
+            "column_end": 2,
+            "is_primary": false,
+            "text":
+            [
+                {
+                    "text": " indented\";",
+                    "highlight_start": 1,
+                    "highlight_end": 2
+                }
+            ],
+            "label": "non-ASCII whitespace symbol '\\u{a0}' is not skipped",
+            "suggested_replacement": null,
+            "suggestion_applicability": null,
+            "expansion": null
+        },
+        {
+            "file_name": "lib.rs",
+            "byte_start": 24,
+            "byte_end": 28,
+            "line_start": 1,
+            "line_end": 2,
+            "column_start": 25,
+            "column_end": 2,
+            "is_primary": true,
+            "text":
+            [
+                {
+                    "text": "pub static FOO: &str = \"\\",
+                    "highlight_start": 25,
+                    "highlight_end": 26
+                },
+                {
+                    "text": " indented\";",
+                    "highlight_start": 1,
+                    "highlight_end": 2
+                }
+            ],
+            "label": null,
+            "suggested_replacement": null,
+            "suggestion_applicability": null,
+            "expansion": null
+        }
+    ],
+    "children":
+    [],
+    "rendered": "warning: non-ASCII whitespace symbol '\\u{a0}' is not skipped\n --> lib.rs:1:25\n  |\n1 |   pub static FOO: &str = \"\\\n  |  _________________________^\n2 | |  indented\";\n  | | ^ non-ASCII whitespace symbol '\\u{a0}' is not skipped\n  | |_|\n  | \n\n"
+}

--- a/tests/edge_cases.rs
+++ b/tests/edge_cases.rs
@@ -22,3 +22,4 @@ expect_empty_json_test! {out_of_bounds_test, "out_of_bounds.recorded.json"}
 expect_empty_json_test! {utf8_identifiers_test, "utf8_idents.recorded.json"}
 expect_empty_json_test! {empty, "empty.json"}
 expect_empty_json_test! {no_main, "no_main.json"}
+expect_empty_json_test! {indented_whitespace, "indented_whitespace.json"}


### PR DESCRIPTION
There is a bug where rustfix would panic on input where the `highlight_start` appears within whitespace characters.  The issue is that the code computing the indent was comparing the indent (which is 0-based) to the `highlight_start` (which is 1-based).  All the following code expects 0-based offsets.

In this particular example, the `let lead = text_slice[indent..start]` would panic because indent is 1 whereas `start` is 0.