### PR TITLE
Fix few clippy lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,11 +182,7 @@ pub fn collect_suggestions<S: ::std::hash::BuildHasher>(
         }
     }
 
-    let snippets = diagnostic
-        .spans
-        .iter()
-        .filter_map(|span| parse_snippet(span))
-        .collect();
+    let snippets = diagnostic.spans.iter().filter_map(parse_snippet).collect();
 
     let solutions: Vec<_> = diagnostic
         .children
@@ -207,7 +203,7 @@ pub fn collect_suggestions<S: ::std::hash::BuildHasher>(
                 })
                 .filter_map(collect_span)
                 .collect();
-            if replacements.len() >= 1 {
+            if !replacements.is_empty() {
                 Some(Solution {
                     message: child.message.clone(),
                     replacements,

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -56,7 +56,7 @@ impl Data {
         self.parts.iter().fold(Vec::new(), |mut acc, d| {
             match d.data {
                 State::Initial => acc.extend_from_slice(&self.original[d.start..=d.end]),
-                State::Replaced(ref d) | State::Inserted(ref d) => acc.extend_from_slice(&d),
+                State::Replaced(ref d) | State::Inserted(ref d) => acc.extend_from_slice(d),
             };
             acc
         })
@@ -164,7 +164,7 @@ impl Data {
 
             // Previous parts
             if let Some(ps) = self.parts.get(..index_of_part_to_split) {
-                new_parts.extend_from_slice(&ps);
+                new_parts.extend_from_slice(ps);
             }
 
             // Keep initial data on left side of part
@@ -198,7 +198,7 @@ impl Data {
 
             // Following parts
             if let Some(ps) = self.parts.get(index_of_part_to_split + 1..) {
-                new_parts.extend_from_slice(&ps);
+                new_parts.extend_from_slice(ps);
             }
 
             new_parts


### PR DESCRIPTION
```
warning: this expression borrows a reference (`&std::rc::Rc<[u8]>`) that is immediately dereferenced by the compiler
  --> src/replace.rs:59:90
   |
59 |                 State::Replaced(ref d) | State::Inserted(ref d) => acc.extend_from_slice(&d),
   |                                                                                          ^^ help: change this to: `d`
   |
   = note: `#[warn(clippy::needless_borrow)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: this expression borrows a reference (`&[replace::Span]`) that is immediately dereferenced by the compiler
   --> src/replace.rs:167:45
    |
167 |                 new_parts.extend_from_slice(&ps);
    |                                             ^^^ help: change this to: `ps`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: this expression borrows a reference (`&[replace::Span]`) that is immediately dereferenced by the compiler
   --> src/replace.rs:201:45
    |
201 |                 new_parts.extend_from_slice(&ps);
    |                                             ^^^ help: change this to: `ps`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: redundant closure
   --> src/lib.rs:188:21
    |
188 |         .filter_map(|span| parse_snippet(span))
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace the closure with the function itself: `parse_snippet`
    |
    = note: `#[warn(clippy::redundant_closure)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure

warning: length comparison to one
   --> src/lib.rs:210:16
    |
210 |             if replacements.len() >= 1 {
    |                ^^^^^^^^^^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!replacements.is_empty()`
    |
    = note: `#[warn(clippy::len_zero)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero
```