### PR TITLE
use new cargo fmt option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,4 +23,4 @@ jobs:
     - uses: actions/checkout@master
     - name: Install Rust
       run: rustup update stable && rustup default stable && rustup component add rustfmt
-    - run: cargo fmt -- --check
+    - run: cargo fmt --check


### PR DESCRIPTION
As of v1.58, cargo fmt now supports the --check flag directly. Updating it here (and in a few other r-l repos) both because it's more succinct and so more people will see/become aware