### PR TITLE
Fix for anynow causing semver-breakage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-anyhow = "1.0.0"
+anyhow = "1.0.6"
 log = "0.4.1"
 
 [dev-dependencies]


### PR DESCRIPTION
The `anyhow` crate intentionally breaks semver rules, and adds new features in "patch" releases. This crate uses `ensure` macro that has been added in a version after 1.0.0.

(the serde dependency is probably broken too, for the same reason)
