### PR TITLE
Make Diagnostic::is_primary public

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -33,7 +33,7 @@ pub struct DiagnosticSpan {
     pub column_end: usize,
     /// Is this a "primary" span -- meaning the point, or one of the points,
     /// where the error occurred?
-    is_primary: bool,
+    pub is_primary: bool,
     /// Source text from the start of line_start to the end of line_end.
     pub text: Vec<DiagnosticSpanLine>,
     /// Label that should be placed at this location (if any)


### PR DESCRIPTION
I'm writing a tool using rustfix that needs to know about primary spans. Currently it relies on the fact that the last span in the list emitted by rustc happens to be a primary one, but it'd be nice if this field was just exposed on the diagnostic itself.