### PR TITLE
Prepare for new release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/rust-lang-nursery/rustfix"
 documentation = "https://docs.rs/rustfix"
 edition = "2018"
 readme = "Readme.md"
-version = "0.6.0"
+version = "0.6.1"
 exclude = [
     "etc/*",
     "examples/*",


### PR DESCRIPTION
This PR bumps `rustfix`'s version from `0.6.0` to `0.6.1`.

I scanned the commits since the [last release](https://github.com/rust-lang/rustfix/commit/e6dabf15236e0a1bb05fc54718cb5f83b0e82da5), and none of them appear to be breaking.

Note that https://github.com/rust-lang/rustfix/pull/207 does expand `rustfix`'s API. But given how Cargo [handles semantic versioning](https://doc.rust-lang.org/cargo/reference/semver.html), this fact only warrants a bump of `z` in `0.y.z`.