### PR TITLE
fix insert at beginning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,11 +239,8 @@ impl CodeFix {
     pub fn apply(&mut self, suggestion: &Suggestion) -> Result<(), Error> {
         for sol in &suggestion.solutions {
             for r in &sol.replacements {
-                self.data.replace_range(
-                    r.snippet.range.start,
-                    r.snippet.range.end.saturating_sub(1),
-                    r.replacement.as_bytes(),
-                )?;
+                self.data
+                    .replace_range(r.snippet.range.clone(), r.replacement.as_bytes())?;
             }
         }
         Ok(())

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -101,9 +101,7 @@ impl Data {
             let index_of_part_to_split = self
                 .parts
                 .iter()
-                .position(|p| {
-                    !p.data.is_inserted() && p.start <= range.start && p.end >= range.end
-                })
+                .position(|p| !p.data.is_inserted() && p.start <= range.start && p.end >= range.end)
                 .ok_or_else(|| {
                     use log::Level::Debug;
                     if log_enabled!(Debug) {


### PR DESCRIPTION
Previously trying to insert some code at the very beginning seems to have caused issues.

Using start=0, end=0 means "replace the first character with the given data", so to properly insert at the beginning the code should call `.replace_range(0, -1, b"...")` (not possible because `-1` is not an `usize`). This commit fixes that by using exclusive ranges instead, so now `.replace_range(0..0, b"...")` inserts at the beginning.